### PR TITLE
fix openfst download link address

### DIFF
--- a/decoders/swig/setup.py
+++ b/decoders/swig/setup.py
@@ -68,7 +68,7 @@ FILES = glob.glob('kenlm/util/*.cc') \
         + glob.glob('kenlm/lm/*.cc') \
         + glob.glob('kenlm/util/double-conversion/*.cc')
 
-FILES += glob.glob('openfst-1.6.3/src/lib/*.cc')
+FILES += glob.glob('openfst-1.6.7/src/lib/*.cc')
 
 FILES = [
     fn for fn in FILES
@@ -104,7 +104,7 @@ decoders_module = [
         include_dirs=[
             '.',
             'kenlm',
-            'openfst-1.6.3/src/include',
+            'openfst-1.6.7/src/include',
             'ThreadPool',
         ],
         libraries=LIBS,

--- a/decoders/swig/setup.sh
+++ b/decoders/swig/setup.sh
@@ -5,10 +5,10 @@ if [ ! -d kenlm ]; then
     echo -e "\n"
 fi
 
-if [ ! -d openfst-1.6.3 ]; then
+if [ ! -d openfst-1.6.7 ]; then
     echo "Download and extract openfst ..."
-    wget http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.6.3.tar.gz
-    tar -xzvf openfst-1.6.3.tar.gz
+    wget https://sites.google.com/site/openfst/home/openfst-down/openfst-1.6.7.tar.gz
+    tar -xzvf openfst-1.6.7.tar.gz
     echo -e "\n"
 fi
 


### PR DESCRIPTION
the old link address (http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.6.3.tar.gz) can't be opened because openfst has been updated .